### PR TITLE
indexing on unicode instead of string

### DIFF
--- a/publications/scripts/trawl_pubmed.py
+++ b/publications/scripts/trawl_pubmed.py
@@ -141,8 +141,8 @@ def search_pubmed(accounts, universities, year=YEAR, verbose=True):
         outfilename = os.path.join(PUBL_DIR, "%s.csv" % account['email'])
         if os.path.exists(outfilename): continue
 
-        name = [account['lastname']]
-        initials = ''.join([n[0] for n in account['firstname'].split()])
+        name = [to_unicode(account['lastname'])]
+        initials = ''.join([n[0] for n in to_unicode(account['firstname']).split()])
         if initials:
             name.append(initials)
         name = ' '.join(name)


### PR DESCRIPTION
The current code crashes when the first letter of the first name i Å,Ä, or Ö. 
Eg. for the first name Åsa below: Where `'\xc3\x85` encodes Å. 
```
account['firstname']
'\xc3\x85sa'
(Pdb) account['firstname'][0]
'\xc3'
```
Doing the same indexing in unicode works as intended and returns Å 